### PR TITLE
fix Ken's Talk radio inconsistency

### DIFF
--- a/data/text/std_text.asm
+++ b/data/text/std_text.asm
@@ -394,3 +394,40 @@ RegisteredNumber2Text:
 	text_ram wStringBuffer3
 	text "'s number."
 	done
+
+OakMissingRadioText:
+	text "You're listening"
+	line "to JOPM, the"
+	para "#MON broadcast"
+	line "station!"
+
+	para "Coming up next is"
+	line "#MON News!"
+
+	para "… World famous"
+	line "#MON researcher"
+	para "PROF. OAK has"
+	line "disappeared from"
+	cont "KANTO!"
+
+	para "Although some"
+	line "consider he may"
+	para "have moved in"
+	line "search of a new"
+	para "place to study,"
+	line "there is also"
+	para "the possibility"
+	line "he was involved"
+	para "in some sort of"
+	line "incident."
+
+	para "Concerned parties"
+	line "are very worried."
+
+	para "…"
+
+	para "And that was"
+	line "#MON News."
+
+	para "…"
+	done

--- a/engine/events/std_scripts.asm
+++ b/engine/events/std_scripts.asm
@@ -206,6 +206,14 @@ HomepageScript:
 	farjumptext HomepageText
 
 Radio1Script:
+	checkevent EVENT_ROUTE_102_SILVER
+	iftrue .kentalk
+	opentext
+	farwritetext OakMissingRadioText
+	waitbutton
+	closetext
+	end
+.kentalk
 	opentext
 	writebyte MAPRADIO_POKEMON_CHANNEL
 	special MapRadio

--- a/maps/PlayersHouse2F.asm
+++ b/maps/PlayersHouse2F.asm
@@ -115,23 +115,7 @@ PlayersHousePosterScript:
 	describedecoration DECODESC_POSTER
 
 PlayersHouseRadioScript:
-	checkevent EVENT_GOT_A_POKEMON_FROM_OAK
-	iftrue .NormalRadio
-	opentext
-	writetext PlayersRadioText1
-	waitbutton
-	closetext
-	end
-
-.NormalRadio:
 	jumpstd radio1
-
-.AbbreviatedRadio:
-	opentext
-	writetext PlayersRadioText4
-	pause 45
-	closetext
-	end
 
 PlayersHouseBookshelfScript:
 	jumpstd picturebookshelf
@@ -169,48 +153,6 @@ PlayersDollText:
 	cont "relative in KANTO."
 	done
 
-PlayersRadioText1:
-	text "<PLAY_G> turned"
-	line "on the radio."
-	
-	para "…"
-
-	para "You're listening"
-	line "to JOPM, the"
-	para "#MON broadcast"
-	line "station!"
-	
-	para "Coming up next is"
-	line "#MON News!"
-	
-	para "… World famous"
-	line "#MON researcher"
-	para "PROF. OAK has"
-	line "disappeared from"
-	cont "KANTO!"
-	
-	para "Although some"
-	line "consider he may"
-	para "have moved in"
-	line "search of a new"
-	para "place to study,"
-	line "there is also"
-	para "the possibility"
-	line "he was involved"
-	para "in some sort of"
-	line "incident."
-	
-	para "Concerned parties"
-	line "are very worried."
-	
-	para "…"
-	
-	para "And that was"
-	line "#MON News."
-	
-	para "…"
-	done
-
 PlayersRadioText2:
 	text "<PLAY_G> turned"
 	line "on the PC."
@@ -233,16 +175,6 @@ PlayersRadioText2:
 	para "#MON researcher"
 	line "OAK"
 	
-	done
-
-PlayersRadioText3:
-	text "This is DJ MARY,"
-	line "your co-host!"
-	done
-
-PlayersRadioText4:
-	text "#MON!"
-	line "#MON CHANNEL…"
 	done
 
 PlayersHouse2F_MapEvents:


### PR DESCRIPTION
Ken's Talk would air after you received a Pokemon from Oak, but when Ken is still in the player's room